### PR TITLE
Fixed a bug that caused pump disappearing on other resource restart

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -574,6 +574,10 @@ if Config.Debug then
 ----- Cleaup on Resource Restart
 
 RegisterNetEvent('onResourceStop',function()
+    if (GetCurrentResourceName() ~= resourceName) then
+        return
+    end
+
     PumpTraderPed:Remove()
     PumpTraderBlip:Remove()
     if SpawnedPump then


### PR DESCRIPTION
Everytime you restarted another resource mms-oilpumps deleted the pump and the trader blip, it should be better now.